### PR TITLE
Have ImmutableDict implement collections.Mapping

### DIFF
--- a/funktown/dictionary.py
+++ b/funktown/dictionary.py
@@ -1,6 +1,8 @@
 from .lookuptree import LookupTree
 
-class ImmutableDict(object):
+import collections
+
+class ImmutableDict(collections.Mapping):
     '''An immutable dictionary class. Access, insertion, and removal
     are guaranteed to have O(log(n)) performance. Constructor takes same
     arguments as builtin dict'''

--- a/unittest.py
+++ b/unittest.py
@@ -5,6 +5,8 @@ import funktown
 from funktown.lookuptree import LookupTree
 from funktown import ImmutableDict, ImmutableVector, ImmutableList
 
+import collections
+
 def treetest():
     t1 = LookupTree({0:0, 32:32, 4:4})
     assert t1.get(0) == 0
@@ -51,6 +53,11 @@ def dicttest():
     assert ImmutableDict() == {}
     assert ImmutableDict().get(1, 2) == 2
 
+def dictismappingtest():
+    start = {'a': 1, 'b': 2, 'c': 3}
+    i_d = ImmutableDict(start)
+    assert isinstance(i_d, collections.Mapping)
+
 def listtest():
     l1 = ImmutableList([2, 3])
     assert l1.conj(1) == [1, 2, 3]
@@ -77,6 +84,7 @@ if __name__ == "__main__":
     treetest()
     vectortest()
     dicttest()
+    dictismappingtest()
     listtest()
     typetest()
     print("All tests passed")


### PR DESCRIPTION
This feels silly, and it may cause issues with really old python versions that don't have the collections module.

But it would make my life easier, when I'm trying to figure out how to deal with a parameter that might be a list, dict, arbitrary object, string, or ImmutableDict.