### PR TITLE
Bug/dict ctor collide

### DIFF
--- a/funktown/dictionary.py
+++ b/funktown/dictionary.py
@@ -24,6 +24,7 @@ class ImmutableDict(object):
         initdict.update(kwargs)
         hashlist = [(hash2(key), (key, initdict[key])) for key in initdict]
         fixed_up = dict(hashlist)
+        #import pdb; pdb.set_trace()
         self.tree = LookupTree(fixed_up)
         self._length = len(initdict)
 

--- a/funktown/dictionary.py
+++ b/funktown/dictionary.py
@@ -1,13 +1,4 @@
-import hashlib
-
 from .lookuptree import LookupTree
-
-
-def hash2(x):
-    # Can't just use the hash object directly:
-    # LookupTree relies on this being numeric
-    h = hashlib.sha512(str(x))
-    return long(h.hexdigest(), 16)
 
 
 class ImmutableDict(object):
@@ -22,7 +13,7 @@ class ImmutableDict(object):
             # Don't want to overwrite what the caller sent
             initdict = initdict.copy()
         initdict.update(kwargs)
-        hashlist = [(hash2(key), (key, initdict[key])) for key in initdict]
+        hashlist = [(hash(key), (key, initdict[key])) for key in initdict]
         fixed_up = dict(hashlist)
         self.tree = LookupTree(fixed_up)
         self._length = len(initdict)
@@ -31,7 +22,7 @@ class ImmutableDict(object):
         '''Returns a new ImmutableDict instance with value associated with key.
         The implicit parameter is not modified.'''
         copydict = ImmutableDict()
-        copydict.tree = self.tree.assoc(hash2(key), (key, value))
+        copydict.tree = self.tree.assoc(hash(key), (key, value))
         copydict._length = self._length + 1
         return copydict
 
@@ -41,10 +32,10 @@ class ImmutableDict(object):
         modifying in-place.'''
         copydict = ImmutableDict()
         if other:
-            vallist = [(hash2(key), (key, other[key])) for key in other]
+            vallist = [(hash(key), (key, other[key])) for key in other]
         else: vallist = []
         if kwargs:
-            vallist += [(hash2(key), (key, kwargs[key])) for key in kwargs]
+            vallist += [(hash(key), (key, kwargs[key])) for key in kwargs]
         copydict.tree = self.tree.multi_assoc(vallist)
         copydict._length = iter_length(copydict.tree)
         return copydict
@@ -52,7 +43,7 @@ class ImmutableDict(object):
     def remove(self, key):
         '''Returns a new ImmutableDict with the given key removed.'''
         copydict = ImmutableDict()
-        copydict.tree = self.tree.remove(hash2(key))
+        copydict.tree = self.tree.remove(hash(key))
         copydict._length = self._length - 1
         return copydict
 
@@ -67,7 +58,7 @@ class ImmutableDict(object):
 
     def __getitem__(self, key):
         try:
-            return self.tree[hash2(key)][1]
+            return self.tree[hash(key)][1]
         except KeyError: raise KeyError(key)
 
     def __iter__(self):
@@ -94,7 +85,7 @@ class ImmutableDict(object):
 
     def __contains__(self, key):
         try:
-            self.tree[hash2(key)]
+            self.tree[hash(key)]
             return True
         except KeyError: return False
 

--- a/funktown/dictionary.py
+++ b/funktown/dictionary.py
@@ -24,7 +24,6 @@ class ImmutableDict(object):
         initdict.update(kwargs)
         hashlist = [(hash2(key), (key, initdict[key])) for key in initdict]
         fixed_up = dict(hashlist)
-        #import pdb; pdb.set_trace()
         self.tree = LookupTree(fixed_up)
         self._length = len(initdict)
 

--- a/funktown/dictionary.py
+++ b/funktown/dictionary.py
@@ -6,10 +6,12 @@ class ImmutableDict(object):
     arguments as builtin dict'''
 
     def __init__(self, initdict=None, **kwargs):
+        import pdb; pdb.set_trace()
         if initdict is None: initdict = {}
+        # Q: Doesn't this trash the caller?
         initdict.update(kwargs)
         hashlist = [(hash(key), (key, initdict[key])) for key in initdict]
-        self.tree = LookupTree(dict(hashlist))
+        self.tree = LookupTree(hashlist)
         self._length = len(initdict)
 
     def assoc(self, key, value):

--- a/funktown/lookuptree.py
+++ b/funktown/lookuptree.py
@@ -1,15 +1,20 @@
+import uuid
+
+_root_index = uuid.uuid4()
+
+
 class LookupTreeNode(object):
-    def __init__(self, index=-1, value=None):
+    def __init__(self, index=_root_index, value=None):
         self.children = [None] * 32
         self.index = index
         self.value = value
 
     def __iter__(self):
-        if self.index == -1:
+        if self.index == _root_index:
             for child in self.children:
                 if child is None:
                     continue
-                if child.index == -1:
+                if child.index == _root_index:
                     for value in child:
                         yield value
                 else: yield child.value
@@ -41,7 +46,7 @@ class LookupTree(object):
         '''Find the value of the node with the given index'''
         node = self.root
         level = 0
-        while node and node.index == -1:
+        while node and node.index == _root_index:
             i = _getbits(index, level)
             node = node.children[i]
             level += 1
@@ -90,7 +95,8 @@ class LookupTree(object):
                 assert ind not in node.children, "Hash (?) collision"
                 node.children[ind] = newnode
                 break
-            elif child.index == -1:
+            elif child.index == _root_index:
+                # This is the root
                 node = child
             else:
                 branch = LookupTreeNode()
@@ -115,7 +121,7 @@ def _assoc_down(node, newnode, level):
     child = node.children[ind]
     if child is None or child.index == newnode.index:
         copynode.children[ind] = newnode
-    elif child.index == -1:
+    elif child.index == _root_index:
         copynode.children[ind] = _assoc_down(child, newnode, level+1)
     else:
         branch = LookupTreeNode()
@@ -146,7 +152,7 @@ def _multi_assoc_down(node, nndict, level):
                 branch = LookupTreeNode()
                 copynode.children[ind] = \
                     _multi_assoc_down(branch, subnndict, level+1)
-        elif child.index == -1:
+        elif child.index == _root_index:
             copynode.children[ind] = \
                 _multi_assoc_down(node, subnndict, level+1)
         else:
@@ -172,7 +178,7 @@ def _remove_down(node, index, level):
 
     if child.index == index:
         copynode.children[ind] = None
-    elif child.index == -1:
+    elif child.index == _root_index:
         copynode.children[ind] = _remove_down(child, index, level+1)
     else:
         return node

--- a/funktown/lookuptree.py
+++ b/funktown/lookuptree.py
@@ -111,7 +111,7 @@ class LookupTree(object):
                 node.children[ind] = newnode
                 break
             elif child.index == _root_index:
-                # This is the root
+                # This is a branch
                 node = child
             else:
                 branch = LookupTreeNode()
@@ -119,46 +119,10 @@ class LookupTree(object):
                 cind = _getbits(child.index, level)
                 node.children[ind] = branch
 
-                # At least part of the problem is a collision when nind == cind
+                # Life gets tricky when...
                 if nind == cind:
-                    msg = ('Warning\n2nd level key collision at level {}:\n'
-                           'initial index: {}\n'
-                           'newnode index == {}\n'
-                           'existing childnode: {}, index == {}\n'
-                           'newnode index beneath branch: {}\n'
-                           'child node index beneath branch: {}\n'
-                           'Trying to insert {}\n'
-                           'into:\n{}')
-                    children = ''
-                    n = 0
-                    for kid in node.children:
-                        if kid is not None:
-                            children += '\n\t{}: {}'.format(n, kid)
-                            n += 1
-                    formatted = msg.format(level-1,  # already incremented
-                                           ind,
-                                           newnode.index,
-                                           child.value,
-                                           child.index,
-                                           nind,
-                                           cind,
-                                           value,
-                                           children)
-                    print formatted
-                    '''
-                    raise NotImplementedError('FIXME: Start here')
-                    assert False, formatted
-                    '''
-                    #import pdb; pdb.set_trace()
-                    # We started out calculating the key for the next level
-                    #cind2 = _getbits(child.index, level+1)
-                    # branch is fresh: everything should be None here.
-                    if branch.children[cind] is not None:
-                        # This isn't my problem
-                        raise NotImplementedError('Yet another collision')
-                    else:
-                        branch.children[cind] = child
-                    # Go ahead and recurse
+                    branch.children[cind] = child
+                    # recurse
                     node = branch
                 else:
                     branch.children[nind] = newnode

--- a/funktown/lookuptree.py
+++ b/funktown/lookuptree.py
@@ -87,6 +87,7 @@ class LookupTree(object):
             level += 1
             child = node.children[ind]
             if child is None or child.index == newnode.index:
+                assert ind not in node.children, "Hash (?) collision"
                 node.children[ind] = newnode
                 break
             elif child.index == -1:
@@ -95,6 +96,7 @@ class LookupTree(object):
                 branch = LookupTreeNode()
                 nind = _getbits(newnode.index, level)
                 cind = _getbits(child.index, level)
+                assert ind not in node.children
                 node.children[ind] = branch
                 branch.children[nind] = newnode
                 branch.children[cind] = child

--- a/funktown/lookuptree.py
+++ b/funktown/lookuptree.py
@@ -121,6 +121,7 @@ class LookupTree(object):
                     for kid in node.children:
                         children += '\n\t{}: {}'.format(n, kid)
                         n += 1
+                    """
                     raise NotImplementedError('FIXME: Start here')
                     assert False, msg.format(ind,
                                              newnode.index,
@@ -129,11 +130,16 @@ class LookupTree(object):
                                              cind,
                                              value,
                                              children)
+                    """
                 node.children[ind] = branch
                 # At least part of the problem is a collision when nind == cind
-                branch.children[nind] = newnode
-                branch.children[cind] = child
-                break
+                if nind == cind:
+                    # Go ahead and recurse
+                    node = branch
+                else:
+                    branch.children[nind] = newnode
+                    branch.children[cind] = child
+                    break
 
     def __iter__(self):
         return iter(self.root)

--- a/funktown/lookuptree.py
+++ b/funktown/lookuptree.py
@@ -19,6 +19,10 @@ class LookupTreeNode(object):
                         yield value
                 else: yield child.value
 
+    def __repr__(self):
+        result = '{}: {}'.format(self.index, self.value)
+        return result
+
 
 class LookupTree(object):
     '''A lookup tree with a branching factor of 32. The constructor
@@ -92,7 +96,8 @@ class LookupTree(object):
             level += 1
             child = node.children[ind]
             if child is None or child.index == newnode.index:
-                assert ind not in node.children, "Hash (?) collision"
+                if child:
+                    assert child.value == newnode.value
                 node.children[ind] = newnode
                 break
             elif child.index == _root_index:
@@ -102,8 +107,30 @@ class LookupTree(object):
                 branch = LookupTreeNode()
                 nind = _getbits(newnode.index, level)
                 cind = _getbits(child.index, level)
-                assert ind not in node.children
+                if nind == cind:
+                    msg = ('2nd level key collision:\n'
+                           'initial index: {}\n'
+                           'newnode index == {}\n'
+                           'existing childnode index == {}\n'
+                           'newnode index beneath branch: {}\n'
+                           'child node index beneath branch: {}\n'
+                           'Trying to insert {}\n'
+                           'into:\n{}')
+                    children = ''
+                    n = 0
+                    for kid in node.children:
+                        children += '\n\t{}: {}'.format(n, kid)
+                        n += 1
+                    raise NotImplementedError('FIXME: Start here')
+                    assert False, msg.format(ind,
+                                             newnode.index,
+                                             child.index,
+                                             nind,
+                                             cind,
+                                             value,
+                                             children)
                 node.children[ind] = branch
+                # At least part of the problem is a collision when nind == cind
                 branch.children[nind] = newnode
                 branch.children[cind] = child
                 break

--- a/funktown/lookuptree.py
+++ b/funktown/lookuptree.py
@@ -108,7 +108,7 @@ class LookupTree(object):
                 nind = _getbits(newnode.index, level)
                 cind = _getbits(child.index, level)
                 if nind == cind:
-                    msg = ('2nd level key collision:\n'
+                    msg = ('Warning\n2nd level key collision:\n'
                            'initial index: {}\n'
                            'newnode index == {}\n'
                            'existing childnode index == {}\n'
@@ -121,20 +121,33 @@ class LookupTree(object):
                     for kid in node.children:
                         children += '\n\t{}: {}'.format(n, kid)
                         n += 1
-                    """
+                    formatted = msg.format(ind,
+                                           newnode.index,
+                                           child.index,
+                                           nind,
+                                           cind,
+                                           value,
+                                           children)
+                    # The child which was there originally is disappearing.
+                    # At least with this particular implementation.
+                    print formatted
+                    '''
                     raise NotImplementedError('FIXME: Start here')
-                    assert False, msg.format(ind,
-                                             newnode.index,
-                                             child.index,
-                                             nind,
-                                             cind,
-                                             value,
-                                             children)
-                    """
+                    assert False, formatted
+                    '''
                 node.children[ind] = branch
                 # At least part of the problem is a collision when nind == cind
                 if nind == cind:
+                    cind2 = _getbits(child.index, level+1)
+                    if cind2 not in branch.children:
+                        branch.children[cind2] = child
+                    else:
+                        # This isn't my problem
+                        raise NotImplementedError('Yet another collision')
                     # Go ahead and recurse
+                    # The problem with this approach is that I'm just arbitrarily
+                    # throwing away the existing child node.
+                    # really need to insert them both
                     node = branch
                 else:
                     branch.children[nind] = newnode

--- a/unittest.py
+++ b/unittest.py
@@ -88,12 +88,15 @@ def ugly_tree_creation_test():
 def brutal_creation_test():
     errors = []
     for i in range(10000):
+        print '@',
         d = {n:n for n in range(i)}
         i_d = ImmutableDict(d)
         for j in range(i):
             if j not in i_d:
                 msg = '@ length {}, index {} got lost'
                 errors.append(msg.format(i, j))
+        if not i % 80:
+            print '!'
     assert not errors, str(errors)
 
 def simpler_dict_collision_test():
@@ -139,7 +142,7 @@ def typetest():
     assert d != l
 
 if __name__ == "__main__":
-    brutal_creation_test()
+    #brutal_creation_test()
     dict_int_test()
     #ugly_tree_creation_test()
     dict_creation_test()

--- a/unittest.py
+++ b/unittest.py
@@ -60,10 +60,43 @@ def dict_creation_test():
     assert len(d1) == initial_length
     assert len(i_d) == initial_length + 1
 
+def dict_int_test():
+    d = {n:n for n in range(16)}
+    d1 = ImmutableDict(d)
+    assert (len(d1.keys()) == 16)
+
+def ugly_tree_creation_test():
+    import pdb; pdb.set_trace()
+    tree = LookupTree()
+    error_values = []
+    for i in range(10000):
+        tree.insert(hash(i), i)
+        n = 0
+        try:
+            for k, v in tree:
+                n += 1
+            if n != i+1:
+                error_values.append(i)
+        except TypeError:
+            print "Quit being able to iterate over tree on insert # %d" % i
+            raise
+    assert not error_values
+
+def simpler_dict_collision_test():
+    d = {n:n for n in range(10000)}
+    i_d = ImmutableDict(d)
+    failures = []
+    result_keys = i_d.keys()
+    for n in range(10000):
+        if n not in result_keys:
+            failures.append(n)
+    if failures:
+        print "Lost %d keys: %s" % (len(failures), failures)
+        assert False, str(failures)
+
 def dict_collision_test():
     l = [uuid.uuid4() for _ in range(10000)]
     d = {str(uid):uid for uid in l}
-    #import pdb; pdb.set_trace()
     i_d = ImmutableDict(d)
     assert len(i_d.keys()) == len(d.keys())
     for k in l:
@@ -92,11 +125,14 @@ def typetest():
     assert d != l
 
 if __name__ == "__main__":
+    dict_int_test()
+    #ugly_tree_creation_test()
+    dict_creation_test()
+    simpler_dict_collision_test()
+    dict_collision_test()
     treetest()
     vectortest()
     dicttest()
-    dict_creation_test()
-    dict_collision_test()
     listtest()
     typetest()
     print("All tests passed")

--- a/unittest.py
+++ b/unittest.py
@@ -86,6 +86,8 @@ def ugly_tree_creation_test():
     assert not error_values
 
 def brutal_creation_test():
+    """ Note that this is incredibly slow and painful.
+    You probably won't want to run it often """
     errors = []
     for i in range(10000):
         print '@',
@@ -112,14 +114,14 @@ def simpler_dict_collision_test():
         assert False, str(failures)
 
 def dict_collision_test():
-    l = [uuid.uuid4() for _ in range(10000)]
-    d = {str(uid):uid for uid in l}
+    l = [str(uuid.uuid4()) for _ in range(10000)]
+    d = {l[n]: n for n in range(10000)}
     i_d = ImmutableDict(d)
     assert len(i_d.keys()) == len(d.keys())
     failures = []
     for k in l:
         if str(k) not in i_d:
-            failures.append(k)
+            failures.append({k: d[k]})
     if failures:
         msg = 'UUID entries lost:'
         for uid in failures:
@@ -150,14 +152,16 @@ def typetest():
     assert d != l
 
 if __name__ == "__main__":
-    #brutal_creation_test()
-    dict_int_test()
-    #ugly_tree_creation_test()
-    dict_creation_test()
-    # This passes now
-    simpler_dict_collision_test()
     # This still fails horribly
     dict_collision_test()
+    simpler_dict_collision_test()
+    # This is simply too slow to run regularly/often
+    # (if at all)
+    # brutal_creation_test()
+    dict_int_test()
+    # TODO: Get this passing
+    # ugly_tree_creation_test()
+    dict_creation_test()
     treetest()
     vectortest()
     dicttest()

--- a/unittest.py
+++ b/unittest.py
@@ -54,8 +54,7 @@ def dicttest():
     assert ImmutableDict().get(1, 2) == 2
 
 def dict_creation_test():
-    d1 = {"a": 1, "b": 2, "c": 3}
-    d2 = d1.copy()
+    d1 = {"a": 1, "b": 2, "c": 3, 4: 'd'}
     initial_length = len(d1)
     i_d = ImmutableDict(d1, d=4)
     assert len(d1) == initial_length
@@ -64,6 +63,7 @@ def dict_creation_test():
 def dict_collision_test():
     l = [uuid.uuid4() for _ in range(10000)]
     d = {str(uid):uid for uid in l}
+    #import pdb; pdb.set_trace()
     i_d = ImmutableDict(d)
     assert len(i_d.keys()) == len(d.keys())
     for k in l:

--- a/unittest.py
+++ b/unittest.py
@@ -152,7 +152,6 @@ def typetest():
     assert d != l
 
 if __name__ == "__main__":
-    # This still fails horribly
     dict_collision_test()
     simpler_dict_collision_test()
     # This is simply too slow to run regularly/often

--- a/unittest.py
+++ b/unittest.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import uuid
+
 import funktown
 
 from funktown.lookuptree import LookupTree
@@ -51,6 +53,22 @@ def dicttest():
     assert ImmutableDict() == {}
     assert ImmutableDict().get(1, 2) == 2
 
+def dict_creation_test():
+    d1 = {"a": 1, "b": 2, "c": 3}
+    d2 = d1.copy()
+    initial_length = len(d1)
+    i_d = ImmutableDict(d1, d=4)
+    assert len(d1) == initial_length
+    assert len(i_d) == initial_length + 1
+
+def dict_collision_test():
+    l = [uuid.uuid4() for _ in range(10000)]
+    d = {str(uid):uid for uid in l}
+    i_d = ImmutableDict(d)
+    assert len(i_d.keys()) == len(d.keys())
+    for k in l:
+        assert i_d[str(k)]
+
 def listtest():
     l1 = ImmutableList([2, 3])
     assert l1.conj(1) == [1, 2, 3]
@@ -77,6 +95,8 @@ if __name__ == "__main__":
     treetest()
     vectortest()
     dicttest()
+    dict_creation_test()
+    dict_collision_test()
     listtest()
     typetest()
     print("All tests passed")

--- a/unittest.py
+++ b/unittest.py
@@ -143,7 +143,7 @@ def typetest():
     v = ImmutableVector()
     d = ImmutableDict()
 
-    assert l != None
+    assert l is not None
     assert v != 3
     assert d != 'a'
 

--- a/unittest.py
+++ b/unittest.py
@@ -66,11 +66,10 @@ def dict_int_test():
     assert (len(d1.keys()) == 16)
 
 def ugly_tree_creation_test():
-    import pdb; pdb.set_trace()
     tree = LookupTree()
     error_values = []
     for i in range(10000):
-        tree.insert(hash(i), i)
+        tree.insert(hash(i), (i, i))
         n = 0
         try:
             for k, v in tree:
@@ -78,9 +77,24 @@ def ugly_tree_creation_test():
             if n != i+1:
                 error_values.append(i)
         except TypeError:
+            # this is failing the first time through the loop, because
+            # integers aren't iterable.
+            # I'm torn about what to think about this fact.
+            # Probably just means I don't understand the tree as well as I thought
             print "Quit being able to iterate over tree on insert # %d" % i
             raise
     assert not error_values
+
+def brutal_creation_test():
+    errors = []
+    for i in range(10000):
+        d = {n:n for n in range(i)}
+        i_d = ImmutableDict(d)
+        for j in range(i):
+            if j not in i_d:
+                msg = '@ length {}, index {} got lost'
+                errors.append(msg.format(i, j))
+    assert not errors, str(errors)
 
 def simpler_dict_collision_test():
     d = {n:n for n in range(10000)}
@@ -125,6 +139,7 @@ def typetest():
     assert d != l
 
 if __name__ == "__main__":
+    brutal_creation_test()
     dict_int_test()
     #ugly_tree_creation_test()
     dict_creation_test()

--- a/unittest.py
+++ b/unittest.py
@@ -116,8 +116,16 @@ def dict_collision_test():
     d = {str(uid):uid for uid in l}
     i_d = ImmutableDict(d)
     assert len(i_d.keys()) == len(d.keys())
+    failures = []
     for k in l:
-        assert i_d[str(k)]
+        if str(k) not in i_d:
+            failures.append(k)
+    if failures:
+        msg = 'UUID entries lost:'
+        for uid in failures:
+            msg += '{}\n'.format(uid)
+        msg += '\n(There are {} of them)'.format(len(failures))
+        assert False, msg
 
 def listtest():
     l1 = ImmutableList([2, 3])
@@ -146,7 +154,9 @@ if __name__ == "__main__":
     dict_int_test()
     #ugly_tree_creation_test()
     dict_creation_test()
+    # This passes now
     simpler_dict_collision_test()
+    # This still fails horribly
     dict_collision_test()
     treetest()
     vectortest()


### PR DESCRIPTION
Fixes issue #7 

This may be too big a PR for what it does: I include a couple of red herrings (switching to SHA512 will probably have unfortunate performance impact, and most/all of the added comments don't really apply to this issue).

The only parts that really seem to make any difference are in the dict's constructor around line 20 (which is really a different issue) and branching to children, starting around line 122 in my version (which is the actual bug fix).

I'd be happy to pare this back to only include those parts, or even just the "real" bug fix around this specific issue. This just seemed like the easiest place to start a conversation.

Thanks!
